### PR TITLE
Fix "kind" attribute for subtitles

### DIFF
--- a/src/app/shared/shaka-player/shaka-player.component.ts
+++ b/src/app/shared/shaka-player/shaka-player.component.ts
@@ -79,8 +79,8 @@ export class ShakaPlayerComponent implements AfterViewInit {
     this.player
       .load(videoUrl)
       .then(() => {
-        this.player.addTextTrackAsync(captionUrlEn, "en", "subtitle", 'text/vtt').then(() => {
-          this.player.addTextTrackAsync(captionUrlEs, "es", "subtitle", 'text/vtt').then(() => {
+        this.player.addTextTrackAsync(captionUrlEn, "en", "subtitles", 'text/vtt').then(() => {
+          this.player.addTextTrackAsync(captionUrlEs, "es", "subtitles", 'text/vtt').then(() => {
             const textTracks = this.player.getTextTracks();
             if (textTracks.length > 0) {
               this.player.setTextTrackVisibility(true);


### PR DESCRIPTION
Problem: Subtitles weren't showing in Safari browser

Description/Solution: The official value for the "kind" attribute of the <track> element is `subtitles` instead of `subtitle`. This can also be found here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track 
Without the correct value, the text tracks will not show in the Safari browser and do not return an error or a useful error message. Chrome, Edge and Firefox ignore it.